### PR TITLE
fix_for_rpm_license_macro

### DIFF
--- a/gost3411-2012.spec
+++ b/gost3411-2012.spec
@@ -64,7 +64,7 @@ install -pm 644 gost3411-2012-sse41.h %{buildroot}%{_includedir}/gost3411-2012/
 #
 #
 #
-# - Copy LICENSE file to %%license for:
+# Copy LICENSE file to %%license for:
 # - SLE 12 SP3 and higher
 # - openSUSE Leap 42.3 and higher
 # - CentOS 7

--- a/gost3411-2012.spec
+++ b/gost3411-2012.spec
@@ -55,7 +55,29 @@ install -pm 644 gost3411-2012-sse41.h %{buildroot}%{_includedir}/gost3411-2012/
 %{_bindir}/gost3411-2012
 %{_mandir}/man1/gost3411-2012*
 
+#
+# Copy LICENSE file to %%doc for:
+# - SLE 12 SP2 and lower
+# - openSUSE Leap 42.2 and lower
+# - CentOS 6
+# - Scientific Linux 6
+#
+#
+#
+# - Copy LICENSE file to %%license for:
+# - SLE 12 SP3 and higher
+# - openSUSE Leap 42.3 and higher
+# - CentOS 7
+# - Scientific Linux 7
+#
+# Fedora distros feel OK to LICENSE being both in %%doc or %%license regardless to their version.
+#
+%if ( 0%{?sle_version} <= 120200 && !0%{?is_opensuse} ) || ( 0%{?sle_version} <= 120200 && 0%{?is_opensuse} ) || 0%{?centos_version} == 600 || 0%{?scientificlinux_version} == 600
 %doc LICENSE README.md
+%else
+%doc README.md
+%license LICENSE
+%endif
 
 %files devel
 %defattr(-, root, root)

--- a/gost3411-2012.spec
+++ b/gost3411-2012.spec
@@ -54,25 +54,32 @@ install -pm 644 gost3411-2012-sse41.h %{buildroot}%{_includedir}/gost3411-2012/
 %defattr(-, root, root)
 %{_bindir}/gost3411-2012
 %{_mandir}/man1/gost3411-2012*
-
 #
 # Copy LICENSE file to %%doc for:
 # - SLE 12 SP2 and lower
 # - openSUSE Leap 42.2 and lower
-# - CentOS 6
-# - Scientific Linux 6
+# - RHEL 6 and lower
+# - CentOS 6 and lower
+# - Scientific Linux 6 and lower
 #
 #
 #
 # Copy LICENSE file to %%license for:
 # - SLE 12 SP3 and higher
 # - openSUSE Leap 42.3 and higher
-# - CentOS 7
-# - Scientific Linux 7
+# - RHEL 7 and higher
+# - CentOS 7 and higher
+# - Scientific Linux 7 and higher
 #
 # Fedora distros feel OK to LICENSE being both in %%doc or %%license regardless to their version.
 #
-%if ( 0%{?sle_version} <= 120200 && !0%{?is_opensuse} ) || ( 0%{?sle_version} <= 120200 && 0%{?is_opensuse} ) || 0%{?centos_version} == 600 || 0%{?scientificlinux_version} == 600
+# Guideline paragraphs about using %%license macro instead of %%doc for LICENSE in spec-files:
+#
+# Fedora: [0] https://fedoraproject.org/wiki/Packaging:LicensingGuidelines?rd=Packaging/LicensingGuidelines#License_Text
+#
+# openSUSE: [1] https://en.opensuse.org/openSUSE:Specfile_guidelines#License_files
+#
+%if ( 0%{?sle_version} <= 120200 && !0%{?is_opensuse} ) || ( 0%{?sle_version} <= 120200 && 0%{?is_opensuse} ) || 0%{?rhel_version} <= 600 || 0%{?centos_version} <= 600 || 0%{?scientificlinux_version} <= 600
 %doc LICENSE README.md
 %else
 %doc README.md


### PR DESCRIPTION
Hello!

Due to [0] https://fedoraproject.org/wiki/Packaging:LicensingGuidelines?rd=Packaging/LicensingGuidelines#License_Text :
```
If the source package includes the text of the license(s) in its own file, then that file, containing the text of the license(s) for the package must be included in %license. If the source package does not include the text of the license(s), the packager should contact upstream and encourage them to correct this mistake.
```

and [1] https://en.opensuse.org/openSUSE:Specfile_guidelines :

```
License files

License files should be marked with %license for newer products. See https://lists.opensuse.org/opensuse-factory/2016-02/msg00167.html for reasoning. %doc should be avoided. To be backward compatible use a definition like:

%if 0%{?suse_version} < 1500
%doc LICENSE
%else
%license LICENSE
%endif
```
let us have a patch, that fixes this requirement.
```
# Copy LICENSE file to %%doc for:
# - SLE 12 SP2 and lower
# - openSUSE Leap 42.2 and lower
# - CentOS 6
# - Scientific Linux 6
```

and
```
# - Copy licence file to %%license for:
# - SLE 12 SP3 and higher
# - openSUSE Leap 42.3 and higher
# - CentOS 7
# - Scientific Linux 7
#
# Fedora distros feel OK to LICENSE being both in %%doc or %%license regardless to their version.
#
```

Distro version identifiers are based on the table from ``` Detect a distribution flavor for special code``` chapter of [2] https://en.opensuse.org/openSUSE:Build_Service_cross_distribution_howto guideline.

Here ``` 0%{?sle_version} <= 120200 && !0%{?is_opensuse} ``` is SLE 12 SP2 and lower (e.g. SP1) and ```0%{?sle_version} <= 120200 && 0%{?is_opensuse}``` is openSUSE Leap 42.2 and lower (e.g. 42.1).