### PR TITLE
Use unaligned SSE2 instructions for loading data.

### DIFF
--- a/gost3411-2012-sse2.h
+++ b/gost3411-2012-sse2.h
@@ -34,10 +34,10 @@
 
 #define LOAD(P, xmm0, xmm1, xmm2, xmm3) { \
     const __m128i *__m128p = (const __m128i *) &P[0]; \
-    xmm0 = _mm_load_si128(&__m128p[0]); \
-    xmm1 = _mm_load_si128(&__m128p[1]); \
-    xmm2 = _mm_load_si128(&__m128p[2]); \
-    xmm3 = _mm_load_si128(&__m128p[3]); \
+    xmm0 = _mm_loadu_si128(&__m128p[0]); \
+    xmm1 = _mm_loadu_si128(&__m128p[1]); \
+    xmm2 = _mm_loadu_si128(&__m128p[2]); \
+    xmm3 = _mm_loadu_si128(&__m128p[3]); \
 }
 
 #define UNLOAD(P, xmm0, xmm1, xmm2, xmm3) { \
@@ -57,10 +57,10 @@
 
 #define X128M(P, xmm0, xmm1, xmm2, xmm3) { \
     const __m128i *__m128p = (const __m128i *) &P[0]; \
-    xmm0 = _mm_xor_si128(xmm0, _mm_load_si128(&__m128p[0])); \
-    xmm1 = _mm_xor_si128(xmm1, _mm_load_si128(&__m128p[1])); \
-    xmm2 = _mm_xor_si128(xmm2, _mm_load_si128(&__m128p[2])); \
-    xmm3 = _mm_xor_si128(xmm3, _mm_load_si128(&__m128p[3])); \
+    xmm0 = _mm_xor_si128(xmm0, _mm_loadu_si128(&__m128p[0])); \
+    xmm1 = _mm_xor_si128(xmm1, _mm_loadu_si128(&__m128p[1])); \
+    xmm2 = _mm_xor_si128(xmm2, _mm_loadu_si128(&__m128p[2])); \
+    xmm3 = _mm_xor_si128(xmm3, _mm_loadu_si128(&__m128p[3])); \
 }
 
 #define _mm_xor_64(mm0, mm1) _mm_xor_si64(mm0, _mm_cvtsi64_m64(mm1))

--- a/gost3411-2012-sse41.h
+++ b/gost3411-2012-sse41.h
@@ -32,10 +32,10 @@
 
 #define LOAD(P, xmm0, xmm1, xmm2, xmm3) { \
     const __m128i *__m128p = (const __m128i *) &P[0]; \
-    xmm0 = _mm_load_si128(&__m128p[0]); \
-    xmm1 = _mm_load_si128(&__m128p[1]); \
-    xmm2 = _mm_load_si128(&__m128p[2]); \
-    xmm3 = _mm_load_si128(&__m128p[3]); \
+    xmm0 = _mm_loadu_si128(&__m128p[0]); \
+    xmm1 = _mm_loadu_si128(&__m128p[1]); \
+    xmm2 = _mm_loadu_si128(&__m128p[2]); \
+    xmm3 = _mm_loadu_si128(&__m128p[3]); \
 }
 
 #define UNLOAD(P, xmm0, xmm1, xmm2, xmm3) { \
@@ -55,10 +55,10 @@
 
 #define X128M(P, xmm0, xmm1, xmm2, xmm3) { \
     const __m128i *__m128p = (const __m128i *) &P[0]; \
-    xmm0 = _mm_xor_si128(xmm0, _mm_load_si128(&__m128p[0])); \
-    xmm1 = _mm_xor_si128(xmm1, _mm_load_si128(&__m128p[1])); \
-    xmm2 = _mm_xor_si128(xmm2, _mm_load_si128(&__m128p[2])); \
-    xmm3 = _mm_xor_si128(xmm3, _mm_load_si128(&__m128p[3])); \
+    xmm0 = _mm_xor_si128(xmm0, _mm_loadu_si128(&__m128p[0])); \
+    xmm1 = _mm_xor_si128(xmm1, _mm_loadu_si128(&__m128p[1])); \
+    xmm2 = _mm_xor_si128(xmm2, _mm_loadu_si128(&__m128p[2])); \
+    xmm3 = _mm_xor_si128(xmm3, _mm_loadu_si128(&__m128p[3])); \
 }
 
 #define _mm_xor_64(mm0, mm1) _mm_xor_si64(mm0, _mm_cvtsi64_m64(mm1))


### PR DESCRIPTION
When using the functions in gost3411-2012-core.c in the context of a shared library `const unsigned char *data` can be passed in from unaligned memory.

Using `_mm_loadu_si128` over `_mm_load_si128` does not imply any speed penalty on recent (Sandy Bridge and later) CPUs.