### PR TITLE
Update gost3411-2012.spec

### DIFF
--- a/gost3411-2012.spec
+++ b/gost3411-2012.spec
@@ -88,6 +88,8 @@ install -pm 644 gost3411-2012-sse41.h %{buildroot}%{_includedir}/gost3411-2012/
 #
 # openSUSE: [1] https://en.opensuse.org/openSUSE:Specfile_guidelines#License_files
 #
+# Distribution detection codes: [2] https://en.opensuse.org/openSUSE:Build_Service_cross_distribution_howto
+#
 %if ( 0%{?sle_version} > 120200 && !0%{?is_opensuse} ) || (0%{?sle_version} > 120200 && 0%{?is_opensuse} ) || 0%{?suse_version} > 1500 || 0%{?rhel_version} > 600 || 0%{?centos_version} > 600 || 0%{?scientificlinux_version} > 600 || 0%{?fedora_version} > 18 || 0%{?mageia} > 4
 %doc README.md
 %license LICENSE LICENSE.GPL2

--- a/gost3411-2012.spec
+++ b/gost3411-2012.spec
@@ -59,8 +59,9 @@ install -pm 644 gost3411-2012-sse41.h %{buildroot}%{_includedir}/gost3411-2012/
 #
 # - RedHat Enterprise Linux 6 and lower
 # - CentOS 6 and lower
-# - Scientific Linux 6 and lower
 # - Fedora 18 and lower
+#
+# - Scientific Linux 6 and lower
 #
 # - SUSE Linux Enterprise 12 SP2 and lower
 # - openSUSE Leap 42.2 and lower
@@ -71,8 +72,9 @@ install -pm 644 gost3411-2012-sse41.h %{buildroot}%{_includedir}/gost3411-2012/
 #
 # - RedHat Enterprise Linux 7 and higher
 # - CentOS 7 and higher
-# - Scientific Linux 7 and higher
 # - Fedora 19 and higher
+#
+# - Scientific Linux 7 and higher
 #
 # - SUSE Linux Enterprise 12 SP3 and higher
 # - openSUSE Leap 42.3 and higher
@@ -80,9 +82,7 @@ install -pm 644 gost3411-2012-sse41.h %{buildroot}%{_includedir}/gost3411-2012/
 #
 # - Mageia 5 and higher
 #
-#
-# Guideline paragraphs about using %%license macro instead of %%doc
-for LICENSE in spec-files:
+# Guideline paragraphs about using %%license macro instead of %%doc for LICENSE in spec-files:
 #
 # Fedora: [0] https://fedoraproject.org/wiki/Packaging:LicensingGuidelines?rd=Packaging/LicensingGuidelines#License_Text
 #

--- a/gost3411-2012.spec
+++ b/gost3411-2012.spec
@@ -56,34 +56,42 @@ install -pm 644 gost3411-2012-sse41.h %{buildroot}%{_includedir}/gost3411-2012/
 %{_mandir}/man1/gost3411-2012*
 #
 # Copy LICENSE file to %%doc for:
-# - SLE 12 SP2 and lower
-# - openSUSE Leap 42.2 and lower
-# - RHEL 6 and lower
+#
+# - RedHat Enterprise Linux 6 and lower
 # - CentOS 6 and lower
 # - Scientific Linux 6 and lower
+# - Fedora 18 and lower
 #
+# - SUSE Linux Enterprise 12 SP2 and lower
+# - openSUSE Leap 42.2 and lower
 #
+# - Mageia 4 and lower
 #
 # Copy LICENSE file to %%license for:
-# - SLE 12 SP3 and higher
-# - openSUSE Leap 42.3 and higher
-# - RHEL 7 and higher
+#
+# - RedHat Enterprise Linux 7 and higher
 # - CentOS 7 and higher
 # - Scientific Linux 7 and higher
+# - Fedora 19 and higher
 #
-# Fedora distros feel OK to LICENSE being both in %%doc or %%license regardless to their version.
+# - SUSE Linux Enterprise 12 SP3 and higher
+# - openSUSE Leap 42.3 and higher
 #
-# Guideline paragraphs about using %%license macro instead of %%doc for LICENSE in spec-files:
+# - Mageia 5 and higher
+#
+#
+# Guideline paragraphs about using %%license macro instead of %%doc
+for LICENSE in spec-files:
 #
 # Fedora: [0] https://fedoraproject.org/wiki/Packaging:LicensingGuidelines?rd=Packaging/LicensingGuidelines#License_Text
 #
 # openSUSE: [1] https://en.opensuse.org/openSUSE:Specfile_guidelines#License_files
 #
-%if ( 0%{?sle_version} <= 120200 && !0%{?is_opensuse} ) || ( 0%{?sle_version} <= 120200 && 0%{?is_opensuse} ) || 0%{?rhel_version} <= 600 || 0%{?centos_version} <= 600 || 0%{?scientificlinux_version} <= 600
-%doc LICENSE LICENSE.GPL2 README.md
-%else
+%if ( 0%{?sle_version} > 120200 && !0%{?is_opensuse} ) || (0%{?sle_version} > 120200 && 0%{?is_opensuse} ) || 0%{?rhel_version} > 600 || 0%{?centos_version} > 600 || 0%{?scientificlinux_version} > 600 || 0%{?fedora_version} > 18 || 0%{?mageia} > 4
 %doc README.md
 %license LICENSE LICENSE.GPL2
+%else
+%doc LICENSE LICENSE.GPL2 README.md
 %endif
 
 %files devel
@@ -103,4 +111,3 @@ install -pm 644 gost3411-2012-sse41.h %{buildroot}%{_includedir}/gost3411-2012/
 
 * Mon Apr 09 2018 alexey@renatasystems.org 0.12-1
 - Initial RPM release
-

--- a/gost3411-2012.spec
+++ b/gost3411-2012.spec
@@ -76,6 +76,7 @@ install -pm 644 gost3411-2012-sse41.h %{buildroot}%{_includedir}/gost3411-2012/
 #
 # - SUSE Linux Enterprise 12 SP3 and higher
 # - openSUSE Leap 42.3 and higher
+# - openSUSE Tumbleweed and its derivatives
 #
 # - Mageia 5 and higher
 #
@@ -87,7 +88,7 @@ for LICENSE in spec-files:
 #
 # openSUSE: [1] https://en.opensuse.org/openSUSE:Specfile_guidelines#License_files
 #
-%if ( 0%{?sle_version} > 120200 && !0%{?is_opensuse} ) || (0%{?sle_version} > 120200 && 0%{?is_opensuse} ) || 0%{?rhel_version} > 600 || 0%{?centos_version} > 600 || 0%{?scientificlinux_version} > 600 || 0%{?fedora_version} > 18 || 0%{?mageia} > 4
+%if ( 0%{?sle_version} > 120200 && !0%{?is_opensuse} ) || (0%{?sle_version} > 120200 && 0%{?is_opensuse} ) || 0%{?suse_version} > 1500 || 0%{?rhel_version} > 600 || 0%{?centos_version} > 600 || 0%{?scientificlinux_version} > 600 || 0%{?fedora_version} > 18 || 0%{?mageia} > 4
 %doc README.md
 %license LICENSE LICENSE.GPL2
 %else


### PR DESCRIPTION
1. Fixed the "negative" condition (```<```) onto "positive" (```>```): https://lists.opensuse.org/opensuse-packaging/2018-11/msg00016.html

BTW: ```<=``` condition merely doesn't work.

2. Added detection for ```Fedora``` and ```Mageia``` distros (given version values are settled after having couple of build-tests on build.opensuse.org).

3. Updated description for %doc <-> %license mechanism.