### PR TITLE
Fixed some typos in help info

### DIFF
--- a/gost3411-2012.c
+++ b/gost3411-2012.c
@@ -99,11 +99,11 @@ usage(void)
     fprintf(stdout, "   -e          Switch endianness when printing out\n");
     fprintf(stdout, "               resulting hash.  Default: least significant\n");
     fprintf(stdout, "               first.  With this options set all bytes in\n");
-    fprintf(stdout, "               resulting hash are printed in reversed\n");
+    fprintf(stdout, "               resulting hash are printed in reverse\n");
     fprintf(stdout, "               order, more precisely, most significant\n");
     fprintf(stdout, "               first.\n");
     fprintf(stdout, "   -v          Print version info and exit.\n");
-    fprintf(stdout, "   -h          Print this help end exit.\n");
+    fprintf(stdout, "   -h          Print this help and exit.\n");
     fprintf(stdout, "\n");
     fprintf(stdout, "Report bugs to <alexey@renatasystems.org>\n");
     exit(0);


### PR DESCRIPTION
1. ```Print this help end exit``` --> ```Print this help and exit```
2. ```in reversed order``` --> ```in reverse order```