### PR TITLE
Actualized VERSION variable value (0.13)

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,15 @@
+Changes with version 0.13											11 Dec 2018
+
+	* Feature: relicense under the dual BSD/GPL-2.0+ license.
+
+	* Feature: use unaligned SSE2 instructions for loading data.
+
+	* Bugfix: improve the distribution detection in the RPM spec.
+
+	* Bugfix: avoid the 'stringop-truncation' warning.
+
+	* Bugfix: simplified version of add512()
+
 Changes with version 0.12                                           20 Apr 2018
 
 	* Feature: Dockerfile added

--- a/gost3411-2012.c
+++ b/gost3411-2012.c
@@ -34,7 +34,7 @@
 
 #define DEFAULT_DIGEST_SIZE 512
 #define ALGNAME "GOST R 34.11-2012"
-#define VERSION "0.12"
+#define VERSION "0.13"
 
 GOST34112012Context *CTX;
 


### PR DESCRIPTION
Actualized VERSION variable value in reason of 0.13 release.

This will fix ```gost3411-2012 -v``` output, which displays wrong ```0.12```.