### PR TITLE
Fix unaligned memory access in stage2

### DIFF
--- a/gost3411-2012-core.c
+++ b/gost3411-2012-core.c
@@ -143,10 +143,13 @@ g(union uint512_u *h, const union uint512_u *N, const unsigned char *m)
 static inline void
 stage2(GOST34112012Context *CTX, const unsigned char *data)
 {
-    g(&(CTX->h), &(CTX->N), data);
+    union uint512_u m;
+
+    memcpy(&m, data, sizeof(m));
+    g(&(CTX->h), &(CTX->N), (const unsigned char *)&m);
 
     add512(&(CTX->N), &buffer512, &(CTX->N));
-    add512(&(CTX->Sigma), (const union uint512_u *) data, &(CTX->Sigma));
+    add512(&(CTX->Sigma), &m, &(CTX->Sigma));
 }
 
 static inline void


### PR DESCRIPTION
Some architectures in some circumstances do not allow unaligned
memory access (such as ARM, MIPS, IA64) triggering SIGBUS. This
patch very crudely fixes this issue.

The issue is found and original fix is proposed by Eric Biggers:

  https://patchwork.kernel.org/patch/10878865/